### PR TITLE
fix wasm memory leak

### DIFF
--- a/include/proxy-wasm/wasm.h
+++ b/include/proxy-wasm/wasm.h
@@ -399,12 +399,15 @@ public:
   ~PluginHandleBase() {
     if (wasm_handle_) {
       wasm_handle_->wasm()->startShutdown(plugin_->key());
+      wasm_handle_->wasm()->wasm_vm()->removeFailCallback(plugin_handle_key_);
     }
   }
 
   std::shared_ptr<PluginBase> &plugin() { return plugin_; }
   std::shared_ptr<WasmBase> &wasm() { return wasm_handle_->wasm(); }
   std::shared_ptr<WasmHandleBase> &wasmHandle() { return wasm_handle_; }
+
+  void setPluginHandleKey(std::string_view key) { plugin_handle_key_ = std::string(key); }
 
   void setRecoverPluginCallback(
       std::function<std::shared_ptr<PluginHandleBase>(std::shared_ptr<WasmHandleBase> &)> &&f) {
@@ -433,6 +436,10 @@ protected:
   std::shared_ptr<WasmHandleBase> wasm_handle_;
   std::function<std::shared_ptr<PluginHandleBase>(std::shared_ptr<WasmHandleBase> &)>
       recover_plugin_callback_;
+
+private:
+  // key for the plugin handle, used to identify the key in fail callbacks
+  std::string plugin_handle_key_;
 };
 
 using PluginHandleFactory = std::function<std::shared_ptr<PluginHandleBase>(

--- a/src/wasm.cc
+++ b/src/wasm.cc
@@ -729,7 +729,7 @@ getOrCreateThreadLocalWasm(const std::shared_ptr<WasmHandleBase> &base_handle,
 
 void setPluginFailCallback(const std::string &key,
                            const std::shared_ptr<WasmHandleBase> &wasm_handle) {
-  wasm_handle->wasm()->wasm_vm()->addFailCallback([key](proxy_wasm::FailState fail_state) {
+  wasm_handle->wasm()->wasm_vm()->addFailCallback(key, [key](proxy_wasm::FailState fail_state) {
     if (fail_state == proxy_wasm::FailState::RuntimeError) {
       // If VM failed, erase the entry so that:
       // 1) we can recreate the new thread local plugin from the same base_wasm.
@@ -819,6 +819,7 @@ std::shared_ptr<PluginHandleBase> getOrCreateThreadLocalPlugin(
   }
   auto plugin_handle = plugin_factory(wasm_handle, plugin);
   cacheLocalPlugin(key, plugin_handle);
+  plugin_handle->setPluginHandleKey(key);
   setPluginFailCallback(key, wasm_handle);
   setPluginRecoverCallback(key, plugin_handle, base_handle, plugin, plugin_factory);
   return plugin_handle;


### PR DESCRIPTION
Add call to removeFailCallback in PluginHandleBase destructor to ensure proper cleanup of fail callbacks.