### PR TITLE
fix: make WasmBase::doAfterVmCallActions reentry-safe (drain-to-local)

### DIFF
--- a/include/proxy-wasm/wasm.h
+++ b/include/proxy-wasm/wasm.h
@@ -160,9 +160,14 @@ public:
     // NB: this may be deleted by a delayed function unless prevented.
     if (!after_vm_call_actions_.empty()) {
       auto self = shared_from_this();
-      while (!self->after_vm_call_actions_.empty()) {
-        auto f = std::move(self->after_vm_call_actions_.front());
-        self->after_vm_call_actions_.pop_front();
+      // Swap the queue into a local before draining so that actions re-added by a
+      // callback during the drain land in the (now-empty) member queue and are picked
+      // up by the next-outer DeferAfterCallActions frame, instead of being re-run in
+      // this same loop (which would spin forever under synchronous reentry — see
+      // higress-group/higress#4034).
+      std::deque<std::function<void()>> local;
+      local.swap(self->after_vm_call_actions_);
+      for (auto &f : local) {
         f();
       }
     }

--- a/test/wasm_test.cc
+++ b/test/wasm_test.cc
@@ -450,4 +450,32 @@ TEST_P(TestVm, CleanupThreadLocalCacheKeys) {
   EXPECT_TRUE(stale_wasms_keys.empty());
 }
 
+// Regression test for higress-group/higress#4034: doAfterVmCallActions() must not
+// spin forever when a queued action re-enqueues itself during the drain. With the old
+// unguarded `while (!empty())` loop this loops forever; with the drain-to-local fix each
+// call runs the snapshot exactly once and the re-added copy is deferred to the next drain.
+TEST_P(TestVm, DoAfterVmCallActionsReentrySafe) {
+  // WasmBase::doAfterVmCallActions() calls shared_from_this(), so the instance must be
+  // owned by a std::shared_ptr (a stack WasmBase would crash).
+  auto wasm = std::make_shared<TestWasm>(makeVm(engine_));
+
+  int count = 0;
+  std::function<void()> f;
+  f = [&]() {
+    ++count;
+    // Re-enqueue self during the drain. Under the old code this would be picked up by the
+    // same loop and never terminate.
+    wasm->addAfterVmCallAction(f);
+  };
+
+  wasm->addAfterVmCallAction(f);
+  // Snapshot {f} runs exactly once; the re-added copy lands in the now-empty member queue.
+  wasm->doAfterVmCallActions();
+  EXPECT_EQ(count, 1); // Returns after one pass (the old while-loop would never return).
+
+  // The re-added copy runs on the next frame (and re-enqueues once more).
+  wasm->doAfterVmCallActions();
+  EXPECT_EQ(count, 2);
+}
+
 } // namespace proxy_wasm


### PR DESCRIPTION
## Problem

`WasmBase::doAfterVmCallActions()` drained its `after_vm_call_actions_` queue with an
unguarded `while (!after_vm_call_actions_.empty())` loop, popping and running one action
at a time. If an action re-enqueues itself (or otherwise adds a new action) *during* the
drain, the freshly-added action is observed by the same loop and executed again in the
same frame. Under synchronous reentry — e.g. a plugin that calls
`injectEncodedDataToFilterChain` from within an after-VM-call action, which schedules
another after-VM-call action — the loop never sees an empty queue and spins forever,
pinning a CPU at 100%.

## Fix

Swap the member queue into a local `std::deque` before draining, then iterate the local
snapshot exactly once. Actions re-added by a callback during the drain land in the
(now-empty) member queue and are therefore picked up by the next-outer
`DeferAfterCallActions` frame instead of being re-run in this loop. This breaks the
synchronous-reentry spin while preserving ordering semantics for legitimately deferred work.

This is a header-only change to a small inline method:

- Zero-ABI / transparent to plugins — no signature or behavior change visible to WASM modules.
- Re-added actions are still executed; they are just deferred to the next-outer frame.

## Test

Adds `TEST_P(TestVm, DoAfterVmCallActionsReentrySafe)` in `test/wasm_test.cc`, wired into the
existing `//test:wasm_test` target. It registers a self-re-enqueuing action and asserts the
count advances by exactly one per `doAfterVmCallActions()` call. On the old code this test
would hang forever (documenting the regression); with the fix each drain runs the snapshot
once and defers the re-added copy.

## Notes

- CI is the build/test gate.
- Merge is intentionally gated on maintainer review — please do not self-merge.

## Refs

- Fixes context: higress-group/higress#4034
- Design: higress-group/higress#4070 (Layer A)
- Spec: SPEC-001